### PR TITLE
fix file upload for modern php versions

### DIFF
--- a/src/net/curl.php
+++ b/src/net/curl.php
@@ -158,22 +158,22 @@ class curl
             $method = 'GET';
         }
         $url = trim($url);
-        if (is_array($params)) {
-            $params = http_build_query($params);
-        }
         switch(strtoupper($method)) {
             case 'GET':
                 $this->options[CURLOPT_CUSTOMREQUEST] = 'GET';
+                if(is_array($params)) {
+                    $params = http_build_query($params);
+                }
                 if($params !== null) {
                     $url .= strpos($url, '?') === false ? "?$params" : "&$params";
                 }
                 break;
             case 'POST':
                 $this->options[CURLOPT_CUSTOMREQUEST] = 'POST';
-                if($params !== null) {
+                curl_setopt($this->curl, CURLOPT_POST, 1);
+                if(is_array($params) || is_string($params)) {
                     curl_setopt($this->curl, CURLOPT_POSTFIELDS, $params);
                 }
-                curl_setopt($this->curl, CURLOPT_POST, 1);
                 break;
             default:
                 $this->options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
@@ -237,6 +237,11 @@ class curl
         }
 
         return $result;
+    }
+
+    public function getCode()
+    {
+        return curl_getinfo($this->curl, CURLINFO_HTTP_CODE);
     }
 
     public function getCharsetFromHeader()


### PR DESCRIPTION
Загрузка файлов через передачу значения @путь/к/файлу отключена с 7 версии php, теперь доступно только через обертку CURLFile.
Нужно убрать принудительное преобразование data через http_build_query
Важно, чтобы CURLOPT_POST был выставлен до CURLOPT_POSTFIELDS

Для справки:
Значение для curl_setopt CURLOPT_POSTFIELDS может быть либо строкой, либо массивом уже очень давно, начиная с php 5.2 - точно. 
Начиная с версии 5.5 добавилась возможность загружать файлы через формирование объекта CURLFile и параметр CURLOPT_SAFE_UPLOAD, который запрещает загружать файлы через @путь/к/файлу (по умолчанию отключен)
С версии 5.6 значение по умолчанию для CURLOPT_SAFE_UPLOAD становится true
С версии 7.0 вводится запрет на загрузку файлов через @

Раньше:
```
$curl = new curl();
$params = [
    'test_file1' => '@/tmp/test1',
    'test_file2' => '@/tmp/test2',
];

$curl->addOptions([
    CURLOPT_SAFE_UPLOAD => false
]);

$curl->prepare('https://example.com', $params, 'POST');
$curl->execute();
```

Теперь:
```
$curl = new curl();
$params = [
    'test_file1' => new \CURLFile('/tmp/test1'),
    'test_file2' => new \CURLFile('/tmp/test2'),
];

$curl->prepare('https://example.com', $params, 'POST');
$curl->execute();
```